### PR TITLE
Adds note on GDI+ dependency to quickstart

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -25,6 +25,7 @@ Description: ScottPlot is a free and open-source plotting library for .NET that 
 
 Create an interactive plot in less than a minute!
 
+* [Setup](quickstart#setup)
 * [Windows Forms](quickstart#windows-forms-quickstart)
 * [WPF](quickstart#wpf-quickstart)
 * [Avalonia](quickstart#avalonia-quickstart)

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,6 @@ Description: ScottPlot is a free and open-source plotting library for .NET that 
 
 Create an interactive plot in less than a minute!
 
-* [Setup](quickstart#setup)
 * [Windows Forms](quickstart#windows-forms-quickstart)
 * [WPF](quickstart#wpf-quickstart)
 * [Avalonia](quickstart#avalonia-quickstart)
@@ -38,6 +37,8 @@ Create an interactive plot in less than a minute!
 * .NET Framework 4.6.1 and newer
 
 _ScottPlot [3.1.6](https://github.com/ScottPlot/ScottPlot/releases/tag/3.1.6) was the final version to support .NET Framework 4.5_
+
+_Linux and MacOS users must install [libgdiplus](quickstart#libgdiplus) to use ScottPlot_
 
 ### ScottPlot Cookbook
 

--- a/src/quickstart/index.md
+++ b/src/quickstart/index.md
@@ -17,6 +17,22 @@ Description: These simple examples demonstrate how to use ScottPlot in the conso
 
 ![](TOC)
 
+## Setup
+
+If you're targeting Windows you should be good to go. If you are targeting MacOS or Linux you'll need to install GDI+ first.
+
+For APT:
+```sh
+sudo apt install libgdiplus
+```
+
+For Brew:
+```sh
+brew install mono-libgdiplus
+```
+
+If your package manager isn't listed consider making a suggestion or pull request [here](https://github.com/ScottPlot/Website) to add it.
+
 ## Console Quickstart
 
 **Step 1:** Install the [`ScottPlot`](https://www.nuget.org/packages/ScottPlot) NuGet package

--- a/src/quickstart/index.md
+++ b/src/quickstart/index.md
@@ -17,22 +17,6 @@ Description: These simple examples demonstrate how to use ScottPlot in the conso
 
 ![](TOC)
 
-## Setup
-
-If you're targeting Windows you should be good to go. If you are targeting MacOS or Linux you'll need to install GDI+ first.
-
-For APT:
-```sh
-sudo apt install libgdiplus
-```
-
-For Brew:
-```sh
-brew install mono-libgdiplus
-```
-
-If your package manager isn't listed consider making a suggestion or pull request [here](https://github.com/ScottPlot/Website) to add it.
-
 ## Console Quickstart
 
 **Step 1:** Install the [`ScottPlot`](https://www.nuget.org/packages/ScottPlot) NuGet package
@@ -128,3 +112,18 @@ avaPlot1.Plot.AddScatter(dataX, dataY);
 ![](src/quickstart-avalonia/screenshot.png)
 
 _Source code for this application is [available on GitHub](https://github.com/ScottPlot/Website/tree/main/src/quickstart/src/quickstart-avalonia)_
+
+
+## libgdiplus
+
+Linux and MacOS require that [libgdiplus](https://www.mono-project.com/docs/gui/libgdiplus) is installed before using ScottPlot:
+
+```sh
+# install with APT
+sudo apt install libgdiplus
+```
+
+```sh
+# install with Brew
+brew install mono-libgdiplus
+```


### PR DESCRIPTION
Adds the following to the top of Quickstart:

![image](https://user-images.githubusercontent.com/8635304/112243776-c4dcbd00-8c13-11eb-84c4-e7562de480fa.png)
