### PR TITLE
Adds F# quickstart

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -29,6 +29,7 @@ Create an interactive plot in less than a minute!
 * [WPF](quickstart#wpf-quickstart)
 * [Avalonia](quickstart#avalonia-quickstart)
 * [Console Application](quickstart#console-quickstart)
+* [Console Application (F#)](quickstart#console-quickstart-f)
 
 ### Supported Platforms
 

--- a/src/quickstart/index.md
+++ b/src/quickstart/index.md
@@ -30,6 +30,24 @@ plt.SaveFig("quickstart.png");
 
 _Source code for this application is [available on GitHub](https://github.com/ScottPlot/Website/tree/main/src/quickstart/src/quickstart-console)_
 
+## Console Quickstart (F#)
+
+**Step 1:** Install the [`ScottPlot`](https://www.nuget.org/packages/ScottPlot) NuGet package
+
+**Step 2:** Add the following to your start-up sequence:
+
+```fs
+let dataX = [| 1.0 .. 5.0 |]
+let dataY = [| for x in dataX -> x * x |]
+let plt = Plot(400, 300);
+plt.AddScatter(dataX, dataY);
+plt.SaveFig("quickstart.png");
+```
+
+![](src/quickstart-console/screenshot.png)
+
+_Source code for this application is [available on GitHub](https://github.com/ScottPlot/Website/tree/main/src/quickstart/src/quickstart-console-fsharp)_
+
 ## Windows Forms Quickstart
 
 **Step 1:** Install the [`ScottPlot.WinForms`](https://www.nuget.org/packages/ScottPlot.WinForms) NuGet package

--- a/src/quickstart/src/quickstart-console-fsharp/Program.fs
+++ b/src/quickstart/src/quickstart-console-fsharp/Program.fs
@@ -1,0 +1,10 @@
+﻿open ScottPlot
+
+[<EntryPoint>]
+let main argv =
+    let dataX = [| 1.0 .. 5.0 |]
+    let dataY = [| for x in dataX -> x * x |]
+    let plt = Plot(400, 300);
+    plt.AddScatter(dataX, dataY);
+    plt.SaveFig("quickstart.png");
+    0

--- a/src/quickstart/src/quickstart-console-fsharp/QuickstartConsoleFSharp.fsproj
+++ b/src/quickstart/src/quickstart-console-fsharp/QuickstartConsoleFSharp.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ScottPlot" Version="4.1.21" />
+  </ItemGroup>
+
+</Project>

--- a/src/quickstart/src/quickstart-console-fsharp/QuickstartConsoleFSharp.sln
+++ b/src/quickstart/src/quickstart-console-fsharp/QuickstartConsoleFSharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "QuickstartConsoleFSharp", "QuickstartConsoleFSharp.fsproj", "{2C110A6A-3F76-4E19-9059-DBA37F38B61D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2C110A6A-3F76-4E19-9059-DBA37F38B61D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C110A6A-3F76-4E19-9059-DBA37F38B61D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C110A6A-3F76-4E19-9059-DBA37F38B61D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C110A6A-3F76-4E19-9059-DBA37F38B61D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {79F066F4-5CA6-4606-9467-E2E797C2FD90}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Mentioned in https://github.com/ScottPlot/ScottPlot/issues/1276

Worth noting that although WPF and WinForms "support" F# in that it won't not work, Avalonia seems to support it as a first-class language. I think several Avalonia contributors are also active in the F# community. It may be worth considering a quickstart (or even demo) for F# on Avalonia, but that probably would require someone who's fluent with F#.